### PR TITLE
Make key4hep image compatible with apptainer

### DIFF
--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           push: true
           context: ./${{matrix.os.dir}}
-          file: ./${{matrix.os.dir}}/Dockerfile
+          file: ./${{matrix.os.dir}}/Dockerfile-sim
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
             REPOSITORY=${{ secrets.DOCKERHUB_REPOSITORY }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,10 +24,10 @@ stages:
       --dockerfile ${DOCKERFILE}
       --build-arg ${BUILD_ARG_1}
       --destination ${DESTINATION}
-  only:
-    # Only build if the generating files change
-    changes:
-      - ${DOCKERFILE}
+  # only:
+  #   # Only build if the generating files change
+  #   changes:
+  #     - ${DOCKERFILE}
 
 build-environment:
   extends: .build_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,9 +28,6 @@ stages:
     # Only build if the generating files change
     changes:
       - ${DOCKERFILE}
-      - entrypoint.sh
-    except:
-      - tags
 
 build-environment:
   extends: .build_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,10 +9,10 @@ stages:
     entrypoint: [""]
   variables:
     DOCKERFILE: <Dockerfile path>
-    REPOSITORY: <argument to the Dockerfile>
-    VERSION: <argument to the Dockerfile>
+    VERSION: devel
+    OSTAG: <Tag suffix corresponding to version>
     # Use single quotes to escape colon
-    DESTINATION: '${CI_REGISTRY_IMAGE}:${VERSION}'
+    DESTINATION: '${CI_REGISTRY_IMAGE}/${IMAGE}:${VERSION}-${OSTAG}'
   before_script:
     # Prepare Kaniko configuration file
     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
@@ -34,21 +34,21 @@ build-environment:
   extends: .build_template
   variables:
     DOCKERFILE: AlmaLinux9/Dockerfile-environment
-    REPOSITORY: infnpd
-    VERSION: devel
+    IMAGE: mucoll-environment
+    OSTAG: el9
 
 build-spack:
   extends: .build_template
   variables:
     DOCKERFILE: AlmaLinux9/Dockerfile-spack
-    REPOSITORY: kkrizka
-    VERSION: devel
+    IMAGE: mucoll-spack
+    OSTAG: el9
   needs: [build-environment]
 
 build-sim:
   extends: .build_template
   variables:
     DOCKERFILE: AlmaLinux9/Dockerfile
-    REPOSITORY: kkrizka
-    VERSION: devel
+    IMAGE: mucoll-sim
+    OSTAG: el9
   needs: [build-spack]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,56 @@
+stages:
+  - build
+
+.build_template:
+  stage: build
+  image:
+    # Use CERN version of the Kaniko image
+    name: gitlab-registry.cern.ch/ci-tools/docker-image-builder
+    entrypoint: [""]
+  variables:
+    DOCKERFILE: <Dockerfile path>
+    BUILD_ARG_1: <argument to the Dockerfile>
+    TAG: latest
+    # Use single quotes to escape colon
+    DESTINATION: '${CI_REGISTRY_IMAGE}:${TAG}'
+  before_script:
+    # Prepare Kaniko configuration file
+    - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
+  script:
+    - printenv
+    # Build and push the image from the given Dockerfile
+    # See https://docs.gitlab.com/ee/ci/variables/predefined_variables.html#variables-reference for available variables
+    - /kaniko/executor --context $CI_PROJECT_DIR
+      --dockerfile ${DOCKERFILE}
+      --build-arg ${BUILD_ARG_1}
+      --destination ${DESTINATION}
+  only:
+    # Only build if the generating files change
+    changes:
+      - ${DOCKERFILE}
+      - entrypoint.sh
+    except:
+      - tags
+
+build-environment:
+  extends: .build_template
+  variables:
+    DOCKERFILE: AlmaLinux9/Dockerfile-environment
+    REPOSITORY: infnpd
+    VERSION: devel
+
+build-spack:
+  extends: .build_template
+  variables:
+    DOCKERFILE: AlmaLinux9/Dockerfile-spack
+    REPOSITORY: kkrizka
+    VERSION: devel
+  needs: [build-environment]
+
+build-sim:
+  extends: .build_template
+  variables:
+    DOCKERFILE: AlmaLinux9/Dockerfile
+    REPOSITORY: kkrizka
+    VERSION: devel
+  needs: [build-spack]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,11 @@ stages:
       --build-arg REPOSITORY=${CI_REGISTRY_IMAGE}
       --build-arg VERSION=${VERSION}
       --destination ${DESTINATION}
+    - echo /kaniko/executor --context $CI_PROJECT_DIR
+      --dockerfile ${DOCKERFILE}
+      --build-arg REPOSITORY=${CI_REGISTRY_IMAGE}
+      --build-arg VERSION=${VERSION}
+      --destination ${DESTINATION}
   # only:
   #   # Only build if the generating files change
   #   changes:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,10 +9,10 @@ stages:
     entrypoint: [""]
   variables:
     DOCKERFILE: <Dockerfile path>
-    BUILD_ARG_1: <argument to the Dockerfile>
-    TAG: latest
+    REPOSITORY: <argument to the Dockerfile>
+    VERSION: <argument to the Dockerfile>
     # Use single quotes to escape colon
-    DESTINATION: '${CI_REGISTRY_IMAGE}:${TAG}'
+    DESTINATION: '${CI_REGISTRY_IMAGE}:${VERSION}'
   before_script:
     # Prepare Kaniko configuration file
     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
@@ -22,7 +22,8 @@ stages:
     # See https://docs.gitlab.com/ee/ci/variables/predefined_variables.html#variables-reference for available variables
     - /kaniko/executor --context $CI_PROJECT_DIR
       --dockerfile ${DOCKERFILE}
-      --build-arg ${BUILD_ARG_1}
+      --build-arg REPOSITORY=${CI_REGISTRY_IMAGE}
+      --build-arg VERSION=${VERSION}
       --destination ${DESTINATION}
   # only:
   #   # Only build if the generating files change

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ stages:
     entrypoint: [""]
   variables:
     DOCKERFILE: <Dockerfile path>
-    VERSION: devel
+    VERSION: ${CI_COMMIT_REF_SLUG}
     OSTAG: <Tag suffix corresponding to version>
     # Use single quotes to escape colon
     DESTINATION: '${CI_REGISTRY_IMAGE}/${IMAGE}:${VERSION}-${OSTAG}'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,22 +38,34 @@ stages:
 build-environment:
   extends: .build_template
   variables:
-    DOCKERFILE: AlmaLinux9/Dockerfile-environment
     IMAGE: mucoll-environment
-    OSTAG: el9
+  parallel:
+    matrix:
+      - DOCKERFILE: AlmaLinux9/Dockerfile-environment
+        OSTAG: el9
+      - DOCKERFILE: CentOS8/Dockerfile-environment
+        OSTAG: cs8stream
 
 build-spack:
   extends: .build_template
   variables:
-    DOCKERFILE: AlmaLinux9/Dockerfile-spack
     IMAGE: mucoll-spack
-    OSTAG: el9
   needs: [build-environment]
+  parallel:
+    matrix:
+      - DOCKERFILE: AlmaLinux9/Dockerfile-spack
+        OSTAG: el9
+      - DOCKERFILE: CentOS8/Dockerfile-spack
+        OSTAG: cs8stream
 
 build-sim:
   extends: .build_template
   variables:
-    DOCKERFILE: AlmaLinux9/Dockerfile
     IMAGE: mucoll-sim
-    OSTAG: el9
   needs: [build-spack]
+  parallel:
+    matrix:
+      - DOCKERFILE: AlmaLinux9/Dockerfile-sim
+        OSTAG: el9
+      - DOCKERFILE: CentOS8/Dockerfile-sim
+        OSTAG: cs8stream

--- a/AlmaLinux9/Dockerfile
+++ b/AlmaLinux9/Dockerfile
@@ -10,7 +10,10 @@ FROM ${REPOSITORY}/mucoll-spack:${VERSION}-el9
 # Adding Key4hep repositories
 RUN mkdir spack-repos
 RUN git clone https://github.com/key4hep/key4hep-spack spack-repos/key4hep-spack && \
+    pushd spack-repos/key4hep-spack && git checkout ec3ae6f && popd && \
     git clone https://github.com/MuonColliderSoft/mucoll-spack spack-repos/mucoll-spack
+# FIXME: The key4hep-spack ec3ae6f ref is the last one known to work. Update to
+# a stable tag once availlable.
 # FIXME: Using `ADD` for debugging. Should use `RUN git clone ...` in production
 # ADD key4hep-spack spack-repos/key4hep-spack
 # ADD mucoll-spack spack-repos/mucoll-spack

--- a/AlmaLinux9/Dockerfile
+++ b/AlmaLinux9/Dockerfile
@@ -24,7 +24,7 @@ RUN source /setenv.sh && \
     spack env activate sim && \
     cp spack-repos/mucoll-spack/environments/mucoll-release/*.yaml $SPACK_ENV && \
     echo "spack env activate sim" >> /setenv.sh && \
-    echo "spack env st" >> /setenv.sh
+    echo "spack env status" >> /setenv.sh
 
 # Concretizing the MuColl stack reusing system packages as external
 RUN source /setenv.sh && \

--- a/AlmaLinux9/Dockerfile
+++ b/AlmaLinux9/Dockerfile
@@ -16,13 +16,13 @@ RUN git clone https://github.com/key4hep/key4hep-spack spack-repos/key4hep-spack
 # ADD mucoll-spack spack-repos/mucoll-spack
 
 # Configuring Key4hep environment
-RUN source /setup_spack.sh && \
+RUN source /opt/setup_spack.sh && \
     spack repo add --scope system spack-repos/key4hep-spack && \
     spack repo add --scope system spack-repos/mucoll-spack && \
     spack env create sim && \
     spack env activate sim && \
     cp spack-repos/mucoll-spack/environments/mucoll-release/*.yaml $SPACK_ENV && \
-    cat /setup_spack.sh > ${HOME}/setup_env.sh && \
+    echo "source /opt/setup_spack.sh" > ${HOME}/setup_env.sh && \
     echo "spack env activate sim" >> ${HOME}/setup_env.sh && \
     echo "spack env status" >> ${HOME}/setup_env.sh
 
@@ -48,7 +48,8 @@ RUN source ${HOME}/setup_env.sh && \
     spack clean -a
 
 RUN source ${HOME}/setup_env.sh && \
-    echo "source ${MUCOLL_STACK}" > /setup_mucoll.sh
+    echo "source ${MUCOLL_STACK}" > /opt/setup_mucoll.sh && \
+    echo "alias setup_mucoll=\"source /opt/setup_mucoll.sh\"" >> /etc/profile.d/aliases.sh
 
 # Setting up users to be used for the local environment setup
 RUN useradd --shell /bin/bash --create-home mucoll

--- a/AlmaLinux9/Dockerfile
+++ b/AlmaLinux9/Dockerfile
@@ -10,10 +10,7 @@ FROM ${REPOSITORY}/mucoll-spack:${VERSION}-el9
 # Adding Key4hep repositories
 RUN mkdir spack-repos
 RUN git clone https://github.com/key4hep/key4hep-spack spack-repos/key4hep-spack && \
-    pushd spack-repos/key4hep-spack && git checkout ec3ae6f && popd && \
     git clone https://github.com/MuonColliderSoft/mucoll-spack spack-repos/mucoll-spack
-# FIXME: The key4hep-spack ec3ae6f ref is the last one known to work. Update to
-# a stable tag once availlable.
 # FIXME: Using `ADD` for debugging. Should use `RUN git clone ...` in production
 # ADD key4hep-spack spack-repos/key4hep-spack
 # ADD mucoll-spack spack-repos/mucoll-spack

--- a/AlmaLinux9/Dockerfile
+++ b/AlmaLinux9/Dockerfile
@@ -50,5 +50,10 @@ RUN source ${HOME}/setup_env.sh && \
 RUN source ${HOME}/setup_env.sh && \
     echo "source ${MUCOLL_STACK}" > /setup_mucoll.sh
 
+# Setting up users to be used for the local environment setup
+RUN useradd --shell /bin/bash --create-home mucoll
+USER mucoll
+WORKDIR /home/mucoll
+
 ENTRYPOINT ["/bin/bash", "--login"]
 

--- a/AlmaLinux9/Dockerfile
+++ b/AlmaLinux9/Dockerfile
@@ -16,7 +16,6 @@ RUN git clone https://github.com/key4hep/key4hep-spack spack-repos/key4hep-spack
 # ADD mucoll-spack spack-repos/mucoll-spack
 
 # Configuring Key4hep environment
-ENV SPACK_ENV_DIR "spack-repos/mucoll-spack/environments/mucoll-release/"
 RUN source /setenv.sh && \
     spack repo add spack-repos/key4hep-spack && \
     spack repo add spack-repos/mucoll-spack && \
@@ -32,7 +31,8 @@ RUN source /setenv.sh && \
     spack concretize --reuse
 
 # Installing fragments of dependency tree in separate layers for cached debugging
-ENV SPACK_INSTALL_OPTS "--only-concrete --no-add --fail-fast"
+ENV SPACK_INSTALL_OPTS "-j1 --only-concrete --no-add --fail-fast"
+RUN cat /proc/cpuinfo
 RUN source /setenv.sh && \
     spack spec -NIt lcio && \
     spack install ${SPACK_INSTALL_OPTS} root && \

--- a/AlmaLinux9/Dockerfile
+++ b/AlmaLinux9/Dockerfile
@@ -48,7 +48,7 @@ RUN source ${HOME}/setup_env.sh && \
     spack clean -a
 
 RUN source ${HOME}/setup_env.sh && \
-    export > /setup_mucoll.sh
+    echo "source ${MUCOLL_STACK}" > /setup_mucoll.sh
 
 ENTRYPOINT ["/bin/bash", "--login"]
 

--- a/AlmaLinux9/Dockerfile
+++ b/AlmaLinux9/Dockerfile
@@ -16,38 +16,39 @@ RUN git clone https://github.com/key4hep/key4hep-spack spack-repos/key4hep-spack
 # ADD mucoll-spack spack-repos/mucoll-spack
 
 # Configuring Key4hep environment
-RUN source /setenv.sh && \
+RUN source /setup_spack.sh && \
     spack repo add --scope system spack-repos/key4hep-spack && \
     spack repo add --scope system spack-repos/mucoll-spack && \
     spack env create sim && \
     spack env activate sim && \
     cp spack-repos/mucoll-spack/environments/mucoll-release/*.yaml $SPACK_ENV && \
-    echo "spack env activate sim" >> /setenv.sh && \
-    echo "spack env status" >> /setenv.sh
+    cat /setup_spack.sh > ${HOME}/setup_env.sh && \
+    echo "spack env activate sim" >> ${HOME}/setup_env.sh && \
+    echo "spack env status" >> ${HOME}/setup_env.sh
 
 # Concretizing the MuColl stack reusing system packages as external
-RUN source /setenv.sh && \
+RUN source ${HOME}/setup_env.sh && \
     spack add mucoll-stack && \
     spack concretize --reuse
 
 # Installing fragments of dependency tree in separate layers for cached debugging
-ENV SPACK_INSTALL_OPTS "-j1 --only-concrete --no-add --fail-fast"
-RUN cat /proc/cpuinfo
-RUN source /setenv.sh && \
+ENV SPACK_INSTALL_OPTS "--only-concrete --no-add --fail-fast"
+
+RUN source ${HOME}/setup_env.sh && \
     spack spec -NIt lcio && \
     spack install ${SPACK_INSTALL_OPTS} root && \
     spack clean -a
-RUN source /setenv.sh && \
+RUN source ${HOME}/setup_env.sh && \
     spack spec -NIt dd4hep && \
     spack install ${SPACK_INSTALL_OPTS} dd4hep && \
     spack clean -a
-RUN source /setenv.sh && \
+RUN source ${HOME}/setup_env.sh && \
     spack spec -NIt && \
     spack install ${SPACK_INSTALL_OPTS} && \
     spack clean -a
 
-RUN source /setenv.sh && \
-    export > /setup.sh
+RUN source ${HOME}/setup_env.sh && \
+    export > /setup_mucoll.sh
 
 ENTRYPOINT ["/bin/bash", "--login"]
 

--- a/AlmaLinux9/Dockerfile
+++ b/AlmaLinux9/Dockerfile
@@ -17,8 +17,8 @@ RUN git clone https://github.com/key4hep/key4hep-spack spack-repos/key4hep-spack
 
 # Configuring Key4hep environment
 RUN source /setenv.sh && \
-    spack repo add spack-repos/key4hep-spack && \
-    spack repo add spack-repos/mucoll-spack && \
+    spack repo add --scope system spack-repos/key4hep-spack && \
+    spack repo add --scope system spack-repos/mucoll-spack && \
     spack env create sim && \
     spack env activate sim && \
     cp spack-repos/mucoll-spack/environments/mucoll-release/*.yaml $SPACK_ENV && \
@@ -45,6 +45,9 @@ RUN source /setenv.sh && \
     spack spec -NIt && \
     spack install ${SPACK_INSTALL_OPTS} && \
     spack clean -a
+
+RUN source /setenv.sh && \
+    export > /setup.sh
 
 ENTRYPOINT ["/bin/bash", "--login"]
 

--- a/AlmaLinux9/Dockerfile-environment
+++ b/AlmaLinux9/Dockerfile-environment
@@ -13,7 +13,7 @@ RUN yum update -y && \
     yum update -y
 
 RUN yum --enablerepo epel groupinstall -y "Development Tools" && \
-    yum --enablerepo epel install -y tmux passwd vim curl findutils gcc-gfortran git gnupg2 hostname iproute python3 python3-pip python3-setuptools unzip
+    yum --enablerepo epel install -y tmux vim curl findutils gcc-gfortran git gnupg2 hostname iproute python3 python3-pip python3-setuptools unzip
 RUN python3 -m pip install boto3
 
 # Installing additional components for use by Spack as external packages

--- a/AlmaLinux9/Dockerfile-environment
+++ b/AlmaLinux9/Dockerfile-environment
@@ -13,11 +13,8 @@ RUN yum update -y && \
     yum update -y
 
 RUN yum --enablerepo epel groupinstall -y "Development Tools" && \
-    yum --enablerepo epel install -y tmux passwd vim curl findutils gcc-c++ gcc gcc-gfortran git gnupg2 hostname iproute make patch python3 python3-pip python3-setuptools texinfo unzip
+    yum --enablerepo epel install -y tmux passwd vim curl findutils gcc-gfortran git gnupg2 hostname iproute make patch python3 python3-pip python3-setuptools unzip
 RUN python3 -m pip install boto3
-
-# Installing newer GCC compiler
-RUN yum --enablerepo epel install -y gcc-toolset-12
 
 # Installing additional components for use by Spack as external packages
 RUN yum --enablerepo epel install -y cmake gettext ninja-build texinfo

--- a/AlmaLinux9/Dockerfile-environment
+++ b/AlmaLinux9/Dockerfile-environment
@@ -20,4 +20,4 @@ RUN python3 -m pip install boto3
 RUN yum --enablerepo epel install -y gcc-toolset-12
 
 # Installing additional components for use by Spack as external packages
-RUN yum --enablerepo epel install -y cmake gettext ninja-build
+RUN yum --enablerepo epel install -y cmake gettext ninja-build texinfo

--- a/AlmaLinux9/Dockerfile-environment
+++ b/AlmaLinux9/Dockerfile-environment
@@ -13,7 +13,7 @@ RUN yum update -y && \
     yum update -y
 
 RUN yum --enablerepo epel groupinstall -y "Development Tools" && \
-    yum --enablerepo epel install -y tmux passwd vim curl findutils gcc-gfortran git gnupg2 hostname iproute make patch python3 python3-pip python3-setuptools unzip
+    yum --enablerepo epel install -y tmux passwd vim curl findutils gcc-gfortran git gnupg2 hostname iproute python3 python3-pip python3-setuptools unzip
 RUN python3 -m pip install boto3
 
 # Installing additional components for use by Spack as external packages

--- a/AlmaLinux9/Dockerfile-sim
+++ b/AlmaLinux9/Dockerfile-sim
@@ -7,7 +7,7 @@ ARG VERSION=devel
 ARG REPOSITORY=infnpd
 FROM ${REPOSITORY}/mucoll-spack:${VERSION}-el9
 
-# Adding Key4hep repositories
+# Adding repositories: Key4hep + MuColl
 RUN mkdir spack-repos
 RUN git clone https://github.com/key4hep/key4hep-spack spack-repos/key4hep-spack && \
     git clone https://github.com/MuonColliderSoft/mucoll-spack spack-repos/mucoll-spack
@@ -35,7 +35,7 @@ RUN source ${HOME}/setup_env.sh && \
 ENV SPACK_INSTALL_OPTS "--only-concrete --no-add --fail-fast"
 
 RUN source ${HOME}/setup_env.sh && \
-    spack spec -NIt lcio && \
+    spack spec -NIt root && \
     spack install ${SPACK_INSTALL_OPTS} root && \
     spack clean -a
 RUN source ${HOME}/setup_env.sh && \

--- a/AlmaLinux9/Dockerfile-spack
+++ b/AlmaLinux9/Dockerfile-spack
@@ -9,7 +9,6 @@ FROM ${REPOSITORY}/mucoll-environment:${VERSION}-el9
 
 # Setting up Spack
 RUN git clone --depth=1 --branch v0.19.1 https://github.com/spack/spack.git /opt/spack && \
-    echo "source /opt/rh/gcc-toolset-12/enable" >> /opt/setup_spack.sh && \
     echo "source /opt/spack/share/spack/setup-env.sh" >> /opt/setup_spack.sh && \
     echo "alias setup_spack=\"source /opt/setup_spack.sh\"" >> /etc/profile.d/aliases.sh
 

--- a/AlmaLinux9/Dockerfile-spack
+++ b/AlmaLinux9/Dockerfile-spack
@@ -8,11 +8,6 @@ ARG REPOSITORY=infnpd
 FROM ${REPOSITORY}/mucoll-environment:${VERSION}-el9
 
 # Setting up Spack
-RUN whoami
-RUN ls /
-RUN ls /opt
-RUN ls
-
 RUN git clone --depth=1 --branch v0.19.1 https://github.com/spack/spack.git /opt/spack && \
     echo "source /opt/rh/gcc-toolset-12/enable" >> /setenv.sh && \
     echo "source /opt/spack/share/spack/setup-env.sh" >> /setenv.sh

--- a/AlmaLinux9/Dockerfile-spack
+++ b/AlmaLinux9/Dockerfile-spack
@@ -9,20 +9,21 @@ FROM ${REPOSITORY}/mucoll-environment:${VERSION}-el9
 
 # Setting up Spack
 RUN git clone --depth=1 --branch v0.19.1 https://github.com/spack/spack.git /opt/spack && \
-    echo "source /opt/rh/gcc-toolset-12/enable" >> /setup_spack.sh && \
-    echo "source /opt/spack/share/spack/setup-env.sh" >> /setup_spack.sh
+    echo "source /opt/rh/gcc-toolset-12/enable" >> /opt/setup_spack.sh && \
+    echo "source /opt/spack/share/spack/setup-env.sh" >> /opt/setup_spack.sh && \
+    echo "alias setup_spack=\"source /opt/setup_spack.sh\"" >> /etc/profile.d/aliases.sh
 
 # Registering compilers with Spack
 ENV SPACK_COLOR="always"
-RUN source /setup_spack.sh && \
+RUN source /opt/setup_spack.sh && \
     spack compiler find && \
     spack compilers && \
     spack spec cmake
 
 # Enabling use of LD_LIBRARY - required for proper run-environment setup
-RUN source /setup_spack.sh && \
+RUN source /opt/setup_spack.sh && \
     spack config add modules:prefix_inspections:lib64:[LD_LIBRARY_PATH] && \
     spack config add modules:prefix_inspections:lib:[LD_LIBRARY_PATH]
 # Adding system build packages as external (to speed up installation)
-RUN source /setup_spack.sh && \
+RUN source /opt/setup_spack.sh && \
     spack external find

--- a/AlmaLinux9/Dockerfile-spack
+++ b/AlmaLinux9/Dockerfile-spack
@@ -8,6 +8,11 @@ ARG REPOSITORY=infnpd
 FROM ${REPOSITORY}/mucoll-environment:${VERSION}-el9
 
 # Setting up Spack
+RUN whoami
+RUN ls /
+RUN ls /opt
+RUN ls
+
 RUN git clone --depth=1 --branch v0.19.1 https://github.com/spack/spack.git /opt/spack && \
     echo "source /opt/rh/gcc-toolset-12/enable" >> /setenv.sh && \
     echo "source /opt/spack/share/spack/setup-env.sh" >> /setenv.sh

--- a/AlmaLinux9/Dockerfile-spack
+++ b/AlmaLinux9/Dockerfile-spack
@@ -9,20 +9,20 @@ FROM ${REPOSITORY}/mucoll-environment:${VERSION}-el9
 
 # Setting up Spack
 RUN git clone --depth=1 --branch v0.19.1 https://github.com/spack/spack.git /opt/spack && \
-    echo "source /opt/rh/gcc-toolset-12/enable" >> /setenv.sh && \
-    echo "source /opt/spack/share/spack/setup-env.sh" >> /setenv.sh
+    echo "source /opt/rh/gcc-toolset-12/enable" >> /setup_spack.sh && \
+    echo "source /opt/spack/share/spack/setup-env.sh" >> /setup_spack.sh
 
 # Registering compilers with Spack
 ENV SPACK_COLOR="always"
-RUN source /setenv.sh && \
+RUN source /setup_spack.sh && \
     spack compiler find && \
     spack compilers && \
     spack spec cmake
 
 # Enabling use of LD_LIBRARY - required for proper run-environment setup
-RUN source /setenv.sh && \
+RUN source /setup_spack.sh && \
     spack config add modules:prefix_inspections:lib64:[LD_LIBRARY_PATH] && \
     spack config add modules:prefix_inspections:lib:[LD_LIBRARY_PATH]
 # Adding system build packages as external (to speed up installation)
-RUN source /setenv.sh && \
+RUN source /setup_spack.sh && \
     spack external find

--- a/AlmaLinux9/build.sh
+++ b/AlmaLinux9/build.sh
@@ -11,14 +11,21 @@ fi
 if [ "$#" -gt 1 ]; then
 	REPOSITORY=$2
 fi
+if [[ -z "${DOCKER}" ]]; then
+    DOCKER="docker"
+fi
 
+# exit when any command fails
+set -e
+
+# The actual building
 echo "### Building Docker images: ${REPOSITORY}/<IMAGE>:${VERSION}-${SUFFIX}"
 echo
-echo "### Building the OS-environment image" && \
-docker build -t ${REPOSITORY}/mucoll-environment:${VERSION}-${SUFFIX} --build-arg REPOSITORY --build-arg VERSION --progress=plain - < Dockerfile-environment && \
+echo "### Building the OS-environment image"
+${DOCKER} build -t ${REPOSITORY}/mucoll-environment:${VERSION}-${SUFFIX} --build-arg REPOSITORY --build-arg VERSION --progress=plain - < Dockerfile-environment
 #
 echo "### Building the Spack image" && \
-docker build -t ${REPOSITORY}/mucoll-spack:${VERSION}-${SUFFIX} --build-arg REPOSITORY --build-arg VERSION --progress=plain - < Dockerfile-spack && \
+${DOCKER} build -t ${REPOSITORY}/mucoll-spack:${VERSION}-${SUFFIX} --build-arg REPOSITORY --build-arg VERSION --progress=plain - < Dockerfile-spack
 #
-echo "### Building the MuColl simulation image" && \
-tar -ch . | docker build -t ${REPOSITORY}/mucoll-sim:${VERSION}-${SUFFIX} --build-arg REPOSITORY --build-arg VERSION --progress=plain -
+echo "### Building the MuColl simulation image"
+${DOCKER} build -t ${REPOSITORY}/mucoll-sim:${VERSION}-${SUFFIX} --build-arg REPOSITORY --build-arg VERSION --progress=plain - < Dockerfile-spack

--- a/CentOS8/Dockerfile-environment
+++ b/CentOS8/Dockerfile-environment
@@ -13,16 +13,8 @@ RUN yum update -y && \
     yum update -y
 
 RUN yum --enablerepo epel groupinstall -y "Development Tools" && \
-    yum --enablerepo epel install -y tmux vim curl findutils gcc-c++ gcc gcc-gfortran git gnupg2 hostname iproute redhat-lsb-core make patch python3 python3-pip python3-setuptools unzip
+    yum --enablerepo epel install -y tmux vim curl findutils gcc-gfortran git gnupg2 hostname iproute redhat-lsb-core python3 python3-pip python3-setuptools unzip
 RUN python3 -m pip install boto3
 
 # Installing newer GCC compiler
 RUN yum --enablerepo epel install -y gcc-toolset-11
-
-# Setting up users to be used for the local environment setup
-RUN echo "root" | passwd --stdin root
-RUN useradd --shell /bin/bash --create-home sim && \
-    echo "sim" | passwd --stdin sim
-USER sim
-WORKDIR /home/sim
-

--- a/CentOS8/Dockerfile-environment
+++ b/CentOS8/Dockerfile-environment
@@ -18,3 +18,6 @@ RUN python3 -m pip install boto3
 
 # Installing newer GCC compiler
 RUN yum --enablerepo epel install -y gcc-toolset-11
+
+# Installing additional components for use by Spack as external packages
+RUN yum --enablerepo epel install -y cmake gettext ninja-build texinfo

--- a/CentOS8/Dockerfile-sim
+++ b/CentOS8/Dockerfile-sim
@@ -13,35 +13,45 @@ RUN git clone https://github.com/key4hep/key4hep-spack spack-repos/key4hep-spack
     git clone https://github.com/MuonColliderSoft/mucoll-spack spack-repos/mucoll-spack
 
 # Configuring Key4hep environment
-ENV SPACK_ENV_DIR "spack-repos/mucoll-spack/environments/mucoll-release/"
-RUN source ~/setenv.sh && \
-    spack repo add spack-repos/key4hep-spack && \
-    spack repo add spack-repos/mucoll-spack && \
+RUN source /opt/setup_spack.sh && \
+    spack repo add --scope system spack-repos/key4hep-spack && \
+    spack repo add --scope system spack-repos/mucoll-spack && \
     spack env create sim && \
     spack env activate sim && \
     cp spack-repos/mucoll-spack/environments/mucoll-release/*.yaml $SPACK_ENV && \
-    echo "spack env activate sim" >> ~/setenv.sh && \
-    echo "spack env st" >> ~/setenv.sh
+    echo "source /opt/setup_spack.sh" > ${HOME}/setup_env.sh && \
+    echo "spack env activate sim" >> ${HOME}/setup_env.sh && \
+    echo "spack env status" >> ${HOME}/setup_env.sh
 
 # Concretizing the MuColl stack reusing system packages as external
-RUN source ~/setenv.sh && \
+RUN source ${HOME}/setup_env.sh && \
     spack add mucoll-stack && \
     spack concretize --reuse
 
 # Installing fragments of dependency tree in separate layers for cached debugging
 ENV SPACK_INSTALL_OPTS "--only-concrete --no-add --fail-fast"
-RUN source ~/setenv.sh && \
+
+RUN source ${HOME}/setup_env.sh && \
     spack spec -NIt root && \
     spack install ${SPACK_INSTALL_OPTS} root && \
     spack clean -a
-RUN source ~/setenv.sh && \
+RUN source ${HOME}/setup_env.sh && \
     spack spec -NIt dd4hep && \
     spack install ${SPACK_INSTALL_OPTS} dd4hep && \
     spack clean -a
-RUN source ~/setenv.sh && \
+RUN source ${HOME}/setup_env.sh && \
     spack spec -NIt && \
     spack install ${SPACK_INSTALL_OPTS} && \
     spack clean -a
+
+RUN source ${HOME}/setup_env.sh && \
+    echo "source ${MUCOLL_STACK}" > /opt/setup_mucoll.sh && \
+    echo "alias setup_mucoll=\"source /opt/setup_mucoll.sh\"" >> /etc/profile.d/aliases.sh
+
+# Setting up users to be used for the local environment setup
+RUN useradd --shell /bin/bash --create-home mucoll
+USER mucoll
+WORKDIR /home/mucoll
 
 ENTRYPOINT ["/bin/bash", "--login"]
 

--- a/CentOS8/Dockerfile-spack
+++ b/CentOS8/Dockerfile-spack
@@ -10,6 +10,7 @@ FROM ${REPOSITORY}/mucoll-environment:${VERSION}-cs8stream
 # Setting up Spack
 RUN git clone --depth=1 --branch v0.19.1 https://github.com/spack/spack.git /opt/spack && \
     echo "source /opt/rh/gcc-toolset-11/enable" >> /opt/setup_spack.sh && \
+    echo "source /opt/spack/share/spack/setup-env.sh" >> /opt/setup_spack.sh && \
     echo "alias setup_spack=\"source /opt/setup_spack.sh\"" >> /etc/profile.d/aliases.sh
 
 # Registering compilers with Spack

--- a/CentOS8/Dockerfile-spack
+++ b/CentOS8/Dockerfile-spack
@@ -8,18 +8,21 @@ ARG REPOSITORY=infnpd
 FROM ${REPOSITORY}/mucoll-environment:${VERSION}-cs8stream
 
 # Setting up Spack
-RUN git clone --depth=1 --branch v0.19.1 https://github.com/spack/spack.git && \
-    echo "source /opt/rh/gcc-toolset-11/enable" >> ~/setenv.sh && \
-    echo "source ~/spack/share/spack/setup-env.sh" >> ~/setenv.sh
+RUN git clone --depth=1 --branch v0.19.1 https://github.com/spack/spack.git /opt/spack && \
+    echo "source /opt/rh/gcc-toolset-11/enable" >> /opt/setup_spack.sh && \
+    echo "alias setup_spack=\"source /opt/setup_spack.sh\"" >> /etc/profile.d/aliases.sh
 
 # Registering compilers with Spack
 ENV SPACK_COLOR="always"
-RUN source ~/setenv.sh && \
+RUN source /opt/setup_spack.sh && \
     spack compiler find && \
     spack compilers && \
     spack spec cmake
 
 # Enabling use of LD_LIBRARY - required for proper run-environment setup
-RUN source ~/setenv.sh && \
+RUN source /opt/setup_spack.sh && \
     spack config add modules:prefix_inspections:lib64:[LD_LIBRARY_PATH] && \
     spack config add modules:prefix_inspections:lib:[LD_LIBRARY_PATH]
+# Adding system build packages as external (to speed up installation)
+RUN source /opt/setup_spack.sh && \
+    spack external find

--- a/CentOS8/build.sh
+++ b/CentOS8/build.sh
@@ -1,10 +1,31 @@
 #!/bin/bash
+# USAGE: ./build.sh [<version>] [<repository>]
 
-echo "### Building the OS-environment image" && \
-docker build -t infnpd/mucoll-environment:2.0-cs8stream --progress=plain - < Dockerfile-environment && \
+VERSION="devel"
+REPOSITORY="infnpd"
+SUFFIX="cs8stream"
+
+if [ "$#" -gt 0 ]; then
+	VERSION=$1
+fi
+if [ "$#" -gt 1 ]; then
+	REPOSITORY=$2
+fi
+if [[ -z "${DOCKER}" ]]; then
+    DOCKER="docker"
+fi
+
+# exit when any command fails
+set -e
+
+# The actual building
+echo "### Building Docker images: ${REPOSITORY}/<IMAGE>:${VERSION}-${SUFFIX}"
+echo
+echo "### Building the OS-environment image"
+${DOCKER} build -t ${REPOSITORY}/mucoll-environment:${VERSION}-${SUFFIX} --build-arg REPOSITORY --build-arg VERSION --progress=plain - < Dockerfile-environment
 #
 echo "### Building the Spack image" && \
-docker build -t infnpd/mucoll-spack:2.0-cs8stream --progress=plain - < Dockerfile-spack && \
+${DOCKER} build -t ${REPOSITORY}/mucoll-spack:${VERSION}-${SUFFIX} --build-arg REPOSITORY --build-arg VERSION --progress=plain - < Dockerfile-spack
 #
-echo "### Building the MuColl simulation image" && \
-tar -ch . | docker build -t infnpd/mucoll-sim:2.0-cs8stream --progress=plain -
+echo "### Building the MuColl simulation image"
+${DOCKER} build -t ${REPOSITORY}/mucoll-sim:${VERSION}-${SUFFIX} --build-arg REPOSITORY --build-arg VERSION --progress=plain - < Dockerfile-spack

--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ A container can be started with the following command.
 docker run -ti --rm --entrypoint /bin/bash infnpd/mucoll-sim:devel-el9
 ```
 
-Two setup scripts are available for loading the environment:
-- `source /setup_spack.sh`: Load the Spack for custom environments.
-- `source /setup_mucoll.sh`: Load the Spack and setup the Muon Collider view.
+Two aliases are available for loading the environment setup scripts:
+- `setup_spack`: Load the Spack for custom environments.
+- `setup_mucoll`: Load the Spack and setup the Muon Collider view.

--- a/README.md
+++ b/README.md
@@ -3,15 +3,28 @@ Docker files for Muon Collider software
 
 ## Building the images
 The incremental images for the framework can be built with the following command:
-```
-cd CentOS8
-docker build -f Dockerfile-environment -t infnpd/mucoll-environment:1.6-centos8stream .
-docker build -f Dockerfile-ilc-base -t infnpd/mucoll-ilc-base:1.6-centos8stream .
-docker build -f Dockerfile-ilc-framework -t infnpd/mucoll-ilc-framework:1.6-centos8stream .
+
+```shell
+cd AlmaLinux8
+./build.sh
 ```
 
-A useful way to test the image is running a shell on the container:
+The build script will create images under the `infnpd` repository and the
+`devel` tag.
+
+Three images are created in sucession:
+- `infnpd/mucoll-environment:devel-el9`: Base OS with developement tools and any other needed system packages.
+- `infnpd/mucoll-spack:devel-el9`: Contains an installation of Spack under `/opt/spack`.
+- `infnpd/mucoll-sim:devel-el9`: Contains the Muon Collider software stack as a Spack environment.
+
+## Running the images
+
+A container can be started with the following command.
+
+```shell
+docker run -ti --rm --entrypoint /bin/bash infnpd/mucoll-sim:devel-el9
 ```
-docker run -ti --rm --entrypoint /bin/bash infnpd/mucoll-ilc-framework:1.6-centos8stream
-```
-and inspect its content.
+
+Two setup scripts are available for loading the environment:
+- `source /setup_spack.sh`: Load the Spack for custom environments.
+- `source /setup_mucoll.sh`: Load the Spack and setup the Muon Collider view.


### PR DESCRIPTION
- Add building using GitLab and GitHub CIs.
- Do not use GCC 12 on Alma9 as it causes problems compiling whizard.
- Two setup scripts are available. The idea is that `setup_mucoll.sh` provides all necessary software for MuColl work.
  - `/opt/setup_mucoll.sh`: Setups the environment through a dump of the envrionment.
  - `/opt/setup_spack.sh`: Setups the spack environment.
- Readd a `mucoll` user for docker users.
- The build scripts have an optional environmental variable `DOCKER` to define the docker command (ie: for podman users).
- Port changes to CentOS8 image.