### PR TITLE
Fix out of scope ARG.

### DIFF
--- a/AlmaLinux9/Dockerfile-sim
+++ b/AlmaLinux9/Dockerfile-sim
@@ -5,21 +5,23 @@
 
 ARG VERSION=release
 ARG REPOSITORY=infnpd
-ARG KEY4HEP_COMMIT
 FROM ${REPOSITORY}/mucoll-spack:${VERSION}-el9
 
 # Adding repositories: Key4hep + MuColl
+ARG KEY4HEP_COMMIT
+ARG MUCOLL_VERSION=release
+
 RUN mkdir spack-repos
 RUN git clone https://github.com/key4hep/key4hep-spack spack-repos/key4hep-spack && \
-    git clone https://github.com/MuonColliderSoft/mucoll-spack spack-repos/mucoll-spack --depth 1 --branch ${VERSION}
+    git clone https://github.com/MuonColliderSoft/mucoll-spack spack-repos/mucoll-spack --depth 1 --branch ${MUCOLL_VERSION}
 # FIXME: Using `ADD` for debugging. Should use `RUN git clone ...` in production
 # ADD key4hep-spack spack-repos/key4hep-spack
 # ADD mucoll-spack spack-repos/mucoll-spack
 
 # Using specific commit of Key4hep repository if requested
-RUN if [ -n ${KEY4HEP_COMMIT} ]; then \
-      cd spack-repos/key4hep-spack \
-      git checkout ${KEY4HEP_COMMIT}
+RUN if [ -n "${KEY4HEP_COMMIT}" ]; then \
+      cd spack-repos/key4hep-spack; \
+      git checkout ${KEY4HEP_COMMIT}; \
     fi
 
 


### PR DESCRIPTION
Fixes two problems with the Dockerfile-sim.

- The `ARG` is only valid before the `FROM`  (or after, if defined after). Thus checkout of the branch `${VERSION}` does not work as `VERSION` is only defined before `FROM`. This MR adds a new `ARG MUCOLL_VERSION=release` that can be used to specify the version. This also means that the image "version" is no longer tied to the mucoll-spack version.
- Fixed a few bash syntax errors in checking out `KEY4HEP_COMMIT`.