### PR TITLE
Install groff for fix man-db build.

### DIFF
--- a/AlmaLinux9/Dockerfile-environment
+++ b/AlmaLinux9/Dockerfile-environment
@@ -17,4 +17,4 @@ RUN yum --enablerepo epel groupinstall -y "Development Tools" && \
 RUN python3 -m pip install boto3
 
 # Installing additional components for use by Spack as external packages
-RUN yum --enablerepo epel install -y cmake gettext ninja-build texinfo
+RUN yum --enablerepo epel install -y cmake gettext ninja-build texinfo groff

--- a/CentOS8/Dockerfile-environment
+++ b/CentOS8/Dockerfile-environment
@@ -20,4 +20,4 @@ RUN python3 -m pip install boto3
 RUN yum --enablerepo epel install -y gcc-toolset-11
 
 # Installing additional components for use by Spack as external packages
-RUN yum --enablerepo epel install -y cmake gettext ninja-build texinfo
+RUN yum --enablerepo epel install -y cmake gettext ninja-build texinfo groff


### PR DESCRIPTION
Installing the `groff` package into the system seems to fix the man-db compilation error listed below. This is [inspired from here](https://github.com/FlorentRevest/asteroid-defunct/issues/2). Unlike the reference, installing `groff-base` (already installed) is not enough.

```
==> Installing man-db-2.11.2-frqavbdbrhf6542gnq6m7ohwugjj3gqk
==> No binary for man-db-2.11.2-frqavbdbrhf6542gnq6m7ohwugjj3gqk found: installing from source
==> Using cached archive: /opt/spack/var/spack/cache/_source-cache/archive/cf/cffa1ee4e974be78646c46508e6dd2f37e7c589aaab2938cc1064f058fef9f8d.tar.xz
==> No patches needed for man-db
==> man-db: Executing phase: 'autoreconf'
==> man-db: Executing phase: 'configure'
==> man-db: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16' 'V=1'

6 errors found in build log:
     2600    Making all in manual
     2601    make[2]: Entering directory '/tmp/root/spack-stage/spack-stage-man-db-2.11.2-frqavbdbrhf6542gnq6m7ohwugjj3gqk/spack-src/manual'
     2602    (echo '.ds V 2.11.2'; echo '.ds td 2023-01-08') > version
     2603    soelim -I. man_db.me | tbl > man_db.pp.new && mv -f man_db.pp.new man_db.pp
     2604    LC_ALL=C nroff -me man_db.pp > man_db.cat.new && mv -f man_db.cat.new man_db.cat
     2605    groff -me -Tps man_db.pp > man_db.ps.new && mv -f man_db.ps.new man_db.ps
  >> 2606    troff: fatal error: can't find macro file e
  >> 2607    make[2]: *** [Makefile:1815: man_db.cat] Error 1
     2608    make[2]: *** Waiting for unfinished jobs....
  >> 2609    troff: fatal error: can't find macro file e
  >> 2610    make[2]: *** [Makefile:1806: man_db.ps] Error 1
     2611    make[2]: Leaving directory '/tmp/root/spack-stage/spack-stage-man-db-2.11.2-frqavbdbrhf6542gnq6m7ohwugjj3gqk/spack-src/manual'
  >> 2612    make[1]: *** [Makefile:1757: all-recursive] Error 1
     2613    make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-man-db-2.11.2-frqavbdbrhf6542gnq6m7ohwugjj3gqk/spack-src'
  >> 2614    make: *** [Makefile:1689: all] Error 2
```