### PR TITLE
removing self-hosted runner

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -14,8 +14,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: self-hosted
-    timeout-minutes: 1440
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         os: [{dir: AlmaLinux9,suffix: alma9}]

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,16 +1,16 @@
 name: build-image
 on:
-  push:
-    branches:
-      - 'master'
-      - 'main'
-      - 'key4hep*'
-    tags:
-      - 'v*'
-  pull_request:
-    branches:
-      - 'master'
-      - 'main'
+  #push:
+  #  branches:
+  #    - 'master'
+  #    - 'main'
+  #    - 'key4hep*'
+  #  tags:
+  #    - 'v*'
+  #pull_request:
+  #  branches:
+  #    - 'master'
+  #    - 'main'
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,16 +1,5 @@
 name: build-image
 on:
-  #push:
-  #  branches:
-  #    - 'master'
-  #    - 'main'
-  #    - 'key4hep*'
-  #  tags:
-  #    - 'v*'
-  #pull_request:
-  #  branches:
-  #    - 'master'
-  #    - 'main'
   workflow_dispatch:
 jobs:
   build:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,6 +48,7 @@ build-spack:
 
 build-sim:
   extends: .build_template
+  timeout: 12h   # set job timeout to 12 hours
   variables:
     IMAGE: mucoll-sim
   needs: [build-spack]


### PR DESCRIPTION
Removing self-hosted runner and testing gitlab integration.

If successful, github build workflows can be removed as gitlab will take care of that